### PR TITLE
Refactor ALL import to reuse dedupeMerge and report per-category stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -1182,6 +1182,7 @@ function download(name, text, type='application/json'){
   a.href = URL.createObjectURL(new Blob([text],{type})); a.download = name; a.click(); URL.revokeObjectURL(a.href);
 }
 const elCat=$("#impCat"), elFile=$("#impFile"), msg=$("#impMsg");
+const supportedCategories = new Set([...elCat.options].map(option => option.value));
 
 $("#btnImport")?.addEventListener('click', async ()=>{
   const cat = elCat.value; const f = elFile.files[0];
@@ -1200,8 +1201,25 @@ $("#btnImportAll")?.addEventListener('click', async ()=>{
   try{
     const obj = JSON.parse(await f.text());
     if (!obj || typeof obj!=='object') throw new Error('Not an object');
-    for (const k of Object.keys(obj)) if (Array.isArray(obj[k])) BANK[k]=obj[k];
-    saveLocal(); updateHomeCounts(); msg.textContent='Imported ALL categories.';
+    const totals = { add:0, skip:0, bad:0, imported:0, ignored:[] };
+    for (const [k, arr] of Object.entries(obj)){
+      if (!Array.isArray(arr)) continue;
+      if (!supportedCategories.has(k)) { totals.ignored.push(k); continue; }
+      BANK[k] = BANK[k] || [];
+      const res = dedupeMerge(BANK[k], arr);
+      totals.add += res.add;
+      totals.skip += res.skip;
+      totals.bad += res.bad;
+      totals.imported++;
+    }
+    saveLocal(); updateHomeCounts();
+    const detail = totals.imported
+      ? `Imported ${totals.imported} categories: +${totals.add} added, ${totals.skip} duplicates, ${totals.bad} invalid.`
+      : 'No supported categories found in ALL import.';
+    const ignored = totals.ignored.length
+      ? ` Ignored unknown categories: ${totals.ignored.join(', ')}.`
+      : '';
+    msg.textContent = detail + ignored;
   }catch(e){ msg.textContent='Parse error: '+e.message; }
 });
 


### PR DESCRIPTION
### Motivation
- Prevent the ALL-import flow from overwriting or silently creating unsupported `BANK` entries and to make its behavior consistent with the per-category `#btnImport` flow.
- Provide admin feedback that mirrors the single-category import by aggregating added/duplicate/invalid counts per category.

### Description
- Added `supportedCategories` derived from the admin `<select id="impCat">` so unknown keys are explicitly ignored during ALL imports rather than being added to `BANK`.
- Rewrote the `#btnImportAll` handler to initialize `BANK[k] = BANK[k] || []` for each incoming category and to call `dedupeMerge(BANK[k], arr)` instead of assigning arrays wholesale.
- Aggregated per-category totals (`add`, `skip`, `bad`, `imported`) and surfaced a combined status message in `#impMsg`, including a list of ignored unknown categories.
- Kept `saveLocal()` and `updateHomeCounts()` after merging so imported data persists and counters refresh.

### Testing
- Ran a quick automated assertion script that checks for the new `supportedCategories` declaration and the updated `#btnImportAll` handler strings (the script executed successfully: `string checks passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb4bbf69883239ab4bf7daabce9b6)