### PR TITLE
Tighten bank uniqueness validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Then open `http://localhost:4173`.
 
 ## Current content volume
 
-- **7 categories**
-- **700 total questions** (100 per category, 4 options each)
+- **7 categories currently in `bank.json`**
+- **840 total rows right now** (120 rows per category, 4 options each)
+- **Shipped gameplay bar:** only claim "100 questions per category" when each category also has **at least 100 unique normalized stems**, not just 100 rows
 
 ## Data layout (merge-conflict friendly)
 
@@ -27,7 +28,7 @@ Then open `http://localhost:4173`.
 - **PWA support**: manifest + service worker + install button.
 - **Offline gameplay**: core assets are cached and still open when the network is down.
 - **Install UX**: when install is available, users get a direct **Install App** button.
-- **Basic quality gate**: question bank schema check via `npm test`.
+- **Gameplay quality gate**: `npm test` keeps the schema checks, enforces at least 100 rows per category, and requires at least 100 unique normalized stems per category so practice variants cannot masquerade as full question volume.
 - **Round randomness**: each round samples unique question stems to avoid near-duplicate variants in the same 10-question run.
 
 ## Deploy on GitHub Pages (recommended)
@@ -66,7 +67,7 @@ If you want a direct `.apk`:
 
 ## Iteration checklist (vibecode to ship-ready)
 
-- [ ] Increase question volume per category.
+- [ ] Increase true question volume per category until every category passes the 100 unique-stem gameplay bar.
 - [ ] Add progress persistence (last category, high scores).
 - [ ] Add UI polish: haptics/sounds, streaks, animations.
 - [ ] Add automated browser E2E checks (Playwright).

--- a/scripts/validate-bank.mjs
+++ b/scripts/validate-bank.mjs
@@ -1,42 +1,86 @@
 import { readFileSync } from 'node:fs';
 
+const MIN_ROWS_PER_CATEGORY = 100;
+const MIN_UNIQUE_STEMS_PER_CATEGORY = 100;
+const MAX_ALLOWED_VARIANTS_PER_STEM = 1;
+
 const bank = JSON.parse(readFileSync(new URL('../bank.json', import.meta.url), 'utf8'));
 const stem = (text) => String(text || '').replace(/\s*\(Practice Variant\s+\d+\)\s*$/i, '').trim();
+const isPracticeVariant = (text) => /\(Practice Variant\s+\d+\)\s*$/i.test(String(text || ''));
 let errorCount = 0;
+const summaries = [];
 
 for (const [category, questions] of Object.entries(bank)) {
-  if (!Array.isArray(questions) || questions.length < 100) {
-    console.error(`Category ${category} has fewer than 100 questions`);
+  if (!Array.isArray(questions)) {
+    console.error(`Category ${category} is not an array of questions`);
     errorCount += 1;
     continue;
   }
 
   const seenExact = new Set();
-  const stemSet = new Set();
+  const stemCounts = new Map();
+  const practiceVariantCounts = new Map();
 
   questions.forEach((q, idx) => {
-    const valid = q && typeof q.question === 'string' && Array.isArray(q.options) && q.options.length === 4 && Number.isInteger(q.correct) && q.correct >= 0 && q.correct <= 3;
+    const valid = q
+      && typeof q.question === 'string'
+      && Array.isArray(q.options)
+      && q.options.length === 4
+      && Number.isInteger(q.correct)
+      && q.correct >= 0
+      && q.correct <= 3;
+
     if (!valid) {
       console.error(`Invalid question schema in ${category}[${idx}]`);
       errorCount += 1;
       return;
     }
 
-    const key = q.question.trim().toLowerCase();
-    if (seenExact.has(key)) {
-      console.error(`Exact duplicate question in ${category}[${idx}]`);
+    const normalizedQuestion = q.question.trim().toLowerCase();
+    if (seenExact.has(normalizedQuestion)) {
+      console.error(`Exact duplicate question in ${category}[${idx}]: ${q.question}`);
       errorCount += 1;
     }
-    seenExact.add(key);
-    stemSet.add(stem(q.question).toLowerCase());
+    seenExact.add(normalizedQuestion);
+
+    const normalizedStem = stem(q.question).toLowerCase();
+    stemCounts.set(normalizedStem, (stemCounts.get(normalizedStem) || 0) + 1);
+
+    if (isPracticeVariant(q.question)) {
+      practiceVariantCounts.set(normalizedStem, (practiceVariantCounts.get(normalizedStem) || 0) + 1);
+    }
   });
 
-  if (stemSet.size < 10) {
-    console.error(`Category ${category} has low stem variety (${stemSet.size}); expected at least 10 unique stems`);
+  const uniqueStemCount = stemCounts.size;
+  summaries.push({ category, rowCount: questions.length, uniqueStemCount });
+
+  if (questions.length < MIN_ROWS_PER_CATEGORY) {
+    console.error(`Category ${category} has ${questions.length} rows; expected at least ${MIN_ROWS_PER_CATEGORY}`);
     errorCount += 1;
+  }
+
+  if (uniqueStemCount < MIN_UNIQUE_STEMS_PER_CATEGORY) {
+    console.error(
+      `Category ${category} has only ${uniqueStemCount} unique stems; expected at least ${MIN_UNIQUE_STEMS_PER_CATEGORY} for shipped gameplay`,
+    );
+    errorCount += 1;
+  }
+
+  for (const [normalizedStem, count] of practiceVariantCounts.entries()) {
+    if (count > MAX_ALLOWED_VARIANTS_PER_STEM) {
+      console.error(
+        `Category ${category} repeats stem "${normalizedStem}" across ${count} practice variants; allowed maximum is ${MAX_ALLOWED_VARIANTS_PER_STEM}`,
+      );
+      errorCount += 1;
+    }
   }
 }
 
 if (errorCount > 0) process.exit(1);
-const total = Object.values(bank).reduce((sum, arr) => sum + arr.length, 0);
-console.log(`Bank OK (${Object.keys(bank).length} categories, ${total} questions validated).`);
+const totalRows = summaries.reduce((sum, { rowCount }) => sum + rowCount, 0);
+const totalUniqueStems = summaries.reduce((sum, { uniqueStemCount }) => sum + uniqueStemCount, 0);
+console.log('Bank OK:');
+for (const { category, rowCount, uniqueStemCount } of summaries) {
+  console.log(`- ${category}: ${rowCount} rows, ${uniqueStemCount} unique stems`);
+}
+console.log(`Total: ${Object.keys(bank).length} categories, ${totalRows} rows, ${totalUniqueStems} unique stems validated.`);


### PR DESCRIPTION
### Motivation
- The existing validator treated raw row counts as gameplay volume and allowed many `(Practice Variant N)` rows to masquerade as distinct questions, which weakens the shipped product promise of “100 questions per category”.
- We need CI to measure gameplay-relevant uniqueness (normalized stems) rather than just row totals so regressions are obvious and authors are guided to add real content.

### Description
- Enhanced `scripts/validate-bank.mjs` to keep the original schema checks while computing per-category row counts and per-category unique normalized stems using the existing `stem()` helper. 
- Enforced a shipped-gameplay threshold of at least `100` unique stems per category and required at least `100` rows per category via `MIN_UNIQUE_STEMS_PER_CATEGORY` and `MIN_ROWS_PER_CATEGORY`.
- Added stricter duplicate policy that still fails on exact duplicate question text and caps `(Practice Variant N)` reuse with `MAX_ALLOWED_VARIANTS_PER_STEM` (set to `1`), and aggregated per-category summaries.
- Updated the success output to print both per-category `rowCount` and `uniqueStemCount`, and a totals line so CI logs surface regressions clearly.
- Updated `README.md` to align claims with the validator: it documents the current row total, explains the new “100 unique normalized stems” gameplay bar, and adjusts the quality-gate / checklist language.

### Testing
- Ran `npm test` (which executes `node scripts/validate-bank.mjs`) and the validator failed as expected because the current `bank.json` only provides ~12 unique stems per category and heavily reuses practice variants; failures include low unique-stem counts and excessive practice-variant repeats. 
- No other automated tests were added or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd2422b2883238a5281685efd80b6)