### PR TITLE
Clarify README content volume and round selection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Then open `http://localhost:4173`.
 ## Current content volume
 
 - **7 categories**
-- **700 total questions** (100 per category, 4 options each)
+- **840 raw rows total in `bank.json`** (**120 rows per category**)
+- **84 unique playable stems total** (**12 unique stems per category**) once `Practice Variant N` suffixes are normalized
+- Each stem currently appears as multiple practice variants, so the bank does **not** yet contain 100 distinct prompts per category
 
 ## Data layout (merge-conflict friendly)
 
@@ -27,8 +29,9 @@ Then open `http://localhost:4173`.
 - **PWA support**: manifest + service worker + install button.
 - **Offline gameplay**: core assets are cached and still open when the network is down.
 - **Install UX**: when install is available, users get a direct **Install App** button.
-- **Basic quality gate**: question bank schema check via `npm test`.
-- **Round randomness**: each round samples unique question stems to avoid near-duplicate variants in the same 10-question run.
+- **Basic quality gate**: `npm test` validates `bank.json` structure, answer integrity, at least 100 raw rows per category, and a minimum unique-stem floor.
+- **Round selection behavior**: rounds are built by **randomized sampling**, not by a fully exhaustive fixed queue. The app groups practice variants by normalized stem, picks up to 10 unique stems per round, prefers stems not seen in the most recent rounds for that category, and only reuses prior stems after that shortlist is exhausted.
+- **Content target (not yet met)**: ship-ready content should reach **100 distinct playable prompts per category**. The current bank is still variant-heavy, so README claims should distinguish raw row count from unique stems until the validator is tightened to enforce that final requirement.
 
 ## Deploy on GitHub Pages (recommended)
 
@@ -66,7 +69,9 @@ If you want a direct `.apk`:
 
 ## Iteration checklist (vibecode to ship-ready)
 
-- [ ] Increase question volume per category.
+- [ ] Expand every category from the current **12 unique stems** to **100 distinct playable prompts** (raw row count alone is not enough).
+- [ ] Tighten the validator so `npm test` fails unless each category has **100 unique normalized stems**, not just 100+ rows and a minimum stem-variety floor.
+- [ ] Keep round generation on randomized stem sampling unless product direction changes to an explicitly exhaustive queue.
 - [ ] Add progress persistence (last category, high scores).
 - [ ] Add UI polish: haptics/sounds, streaks, animations.
 - [ ] Add automated browser E2E checks (Playwright).


### PR DESCRIPTION
### Motivation

- Make README wording precise by separating raw bank rows from unique playable stems and removing any premature claims of 100 distinct prompts per category.  
- Clarify how rounds are selected so product expectations match implementation (randomized sampling of normalized stems vs an exhaustive queue).  
- Record the intended ship-ready requirement of 100 distinct playable prompts per category and note that the validator will need to enforce that.

### Description

- Updated the `## Current content volume` section in `README.md` to report **840 raw rows total in `bank.json` (120 per category)** and **84 unique playable stems total (12 per category)** after normalizing `Practice Variant N` suffixes, and to state that the bank does **not** yet contain 100 distinct prompts per category.  
- Rewrote `## What changed for "next level"` to state that `npm test` validates `bank.json` structure, answer integrity, a 100+ raw-row floor per category and a minimum unique-stem floor, and to document that rounds are assembled by **randomized sampling** of normalized stems with preference for stems not recently used.  
- Revised the `## Iteration checklist` to require expanding each category from the current **12 unique stems** to **100 distinct playable prompts** and to call out tightening the validator so `npm test` enforces 100 unique normalized stems per category.

### Testing

- Ran `npm test` which executed the bank validator and succeeded with the output: `Bank OK (7 categories, 840 questions validated)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd245ea1c832393d5e6052f68092d)