### PR TITLE
Tighten normalized question stem handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then open `http://localhost:4173`.
 
 - **7 categories**
 - **840 raw rows total in `bank.json`** (**120 rows per category**)
-- **84 unique playable stems total** (**12 unique stems per category**) once `Practice Variant N` suffixes are normalized
+- **672 unique playable stems total** (**96 unique stems per category**) once the current wrapper prefixes and `Practice Variant N` suffixes are normalized
 - Each stem currently appears as multiple practice variants, so the bank does **not** yet contain 100 distinct prompts per category
 
 ## Data layout (merge-conflict friendly)
@@ -29,9 +29,9 @@ Then open `http://localhost:4173`.
 - **PWA support**: manifest + service worker + install button.
 - **Offline gameplay**: core assets are cached and still open when the network is down.
 - **Install UX**: when install is available, users get a direct **Install App** button.
-- **Basic quality gate**: `npm test` validates `bank.json` structure, answer integrity, at least 100 raw rows per category, and a minimum unique-stem floor.
+- **Basic quality gate**: `npm test` validates `bank.json` structure, answer integrity, at least 100 raw rows per category, and 100 unique normalized stems per category after wrapper/punctuation normalization.
 - **Round selection behavior**: rounds are built by **randomized sampling**, not by a fully exhaustive fixed queue. The app groups practice variants by normalized stem, picks up to 10 unique stems per round, prefers stems not seen in the most recent rounds for that category, and only reuses prior stems after that shortlist is exhausted.
-- **Content target (not yet met)**: ship-ready content should reach **100 distinct playable prompts per category**. The current bank is still variant-heavy, so README claims should distinguish raw row count from unique stems until the validator is tightened to enforce that final requirement.
+- **Content target (not yet met)**: ship-ready content should reach **100 distinct playable prompts per category**. The current bank normalizes down to **96 unique stems per category**, so `npm test` now fails until the remaining wrapper/variant duplicates are replaced with new prompts.
 
 ## Deploy on GitHub Pages (recommended)
 
@@ -69,8 +69,8 @@ If you want a direct `.apk`:
 
 ## Iteration checklist (vibecode to ship-ready)
 
-- [ ] Expand every category from the current **12 unique stems** to **100 distinct playable prompts** (raw row count alone is not enough).
-- [ ] Tighten the validator so `npm test` fails unless each category has **100 unique normalized stems**, not just 100+ rows and a minimum stem-variety floor.
+- [ ] Expand every category from the current **96 unique normalized stems** to **100 distinct playable prompts** (raw row count alone is not enough).
+- [x] Tighten the validator so `npm test` fails unless each category has **100 unique normalized stems**, not just 100+ rows and a minimum stem-variety floor.
 - [ ] Keep round generation on randomized stem sampling unless product direction changes to an explicitly exhaustive queue.
 - [ ] Add progress persistence (last category, high scores).
 - [ ] Add UI polish: haptics/sounds, streaks, animations.

--- a/index.html
+++ b/index.html
@@ -1048,7 +1048,29 @@ let persistedRoundQueues = loadRoundQueueState();
 
 function shuffle(a){ for (let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } return a; }
 function pickN(arr,n){ const copy=[...(arr||[])]; shuffle(copy); return copy.slice(0, Math.min(n, copy.length)); }
-function questionStem(text){ return String(text||'').replace(/\s*\(Practice Variant\s+\d+\)\s*$/i,'').trim(); }
+const PRACTICE_VARIANT_SUFFIX = /\s*\(Practice Variant\s+\d+\)\s*$/i;
+const STEM_WRAPPER_PREFIXES = [
+  /^\s*Identify the correct answer for this prompt:\s*/i,
+  /^\s*Choose the option that best answers this question:\s*/i,
+];
+function stripStemWrappers(text){
+  let normalized = String(text||'').trim();
+  normalized = normalized.replace(PRACTICE_VARIANT_SUFFIX, '').trim();
+  STEM_WRAPPER_PREFIXES.forEach(prefix => {
+    normalized = normalized.replace(prefix, '').trim();
+  });
+  return normalized
+    .replace(/([!?.,:;])\1+/g, '$1')
+    .replace(/\s*([!?.,:;])\s*/g, '$1 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+function normalizeQuestionStem(text){
+  return stripStemWrappers(text).toLowerCase();
+}
+function questionStem(text){
+  return stripStemWrappers(text);
+}
 function cleanExplanation(text){ return String(text||'').replace(/\s*Variant\s+\d+\s+keeps\s+the\s+same\s+concept\s+with\s+reordered\s+options\.?\s*$/i,'').trim(); }
 function loadRoundQueueState(){
   try{
@@ -1072,7 +1094,7 @@ function saveRoundQueueState(){
 function buildCategoryPool(cat){
   const groups = new Map();
   for (const q of (BANK[cat] || [])){
-    const stem = questionStem(q.question);
+    const stem = normalizeQuestionStem(q.question);
     if (!stem) continue;
     if (!groups.has(stem)) groups.set(stem, []);
     groups.get(stem).push(q);

--- a/scripts/validate-bank.mjs
+++ b/scripts/validate-bank.mjs
@@ -3,10 +3,28 @@ import { readFileSync } from 'node:fs';
 const MIN_ROWS_PER_CATEGORY = 100;
 const MIN_UNIQUE_STEMS_PER_CATEGORY = 100;
 const MAX_ALLOWED_VARIANTS_PER_STEM = 1;
+const PRACTICE_VARIANT_SUFFIX = /\s*\(Practice Variant\s+\d+\)\s*$/i;
+const WRAPPER_PREFIXES = [
+  /^\s*Identify the correct answer for this prompt:\s*/i,
+  /^\s*Choose the option that best answers this question:\s*/i,
+];
 
 const bank = JSON.parse(readFileSync(new URL('../bank.json', import.meta.url), 'utf8'));
-const stem = (text) => String(text || '').replace(/\s*\(Practice Variant\s+\d+\)\s*$/i, '').trim();
-const isPracticeVariant = (text) => /\(Practice Variant\s+\d+\)\s*$/i.test(String(text || ''));
+
+function normalizeStem(text) {
+  let normalized = String(text || '').trim().toLowerCase();
+  normalized = normalized.replace(PRACTICE_VARIANT_SUFFIX, '').trim();
+  for (const prefix of WRAPPER_PREFIXES) {
+    normalized = normalized.replace(prefix, '').trim();
+  }
+  normalized = normalized
+    .replace(/([!?.,:;])\1+/g, '$1')
+    .replace(/\s*([!?.,:;])\s*/g, '$1 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return normalized;
+}
+
 let errorCount = 0;
 const summaries = [];
 
@@ -19,7 +37,6 @@ for (const [category, questions] of Object.entries(bank)) {
 
   const seenExact = new Set();
   const stemCounts = new Map();
-  const practiceVariantCounts = new Map();
 
   questions.forEach((q, idx) => {
     const valid = q
@@ -43,12 +60,8 @@ for (const [category, questions] of Object.entries(bank)) {
     }
     seenExact.add(normalizedQuestion);
 
-    const normalizedStem = stem(q.question).toLowerCase();
+    const normalizedStem = normalizeStem(q.question);
     stemCounts.set(normalizedStem, (stemCounts.get(normalizedStem) || 0) + 1);
-
-    if (isPracticeVariant(q.question)) {
-      practiceVariantCounts.set(normalizedStem, (practiceVariantCounts.get(normalizedStem) || 0) + 1);
-    }
   });
 
   const uniqueStemCount = stemCounts.size;
@@ -66,10 +79,10 @@ for (const [category, questions] of Object.entries(bank)) {
     errorCount += 1;
   }
 
-  for (const [normalizedStem, count] of practiceVariantCounts.entries()) {
+  for (const [normalizedStem, count] of stemCounts.entries()) {
     if (count > MAX_ALLOWED_VARIANTS_PER_STEM) {
       console.error(
-        `Category ${category} repeats stem "${normalizedStem}" across ${count} practice variants; allowed maximum is ${MAX_ALLOWED_VARIANTS_PER_STEM}`,
+        `Category ${category} repeats normalized stem "${normalizedStem}" across ${count} rows; allowed maximum is ${MAX_ALLOWED_VARIANTS_PER_STEM}`,
       );
       errorCount += 1;
     }


### PR DESCRIPTION
### Motivation
- Prevent wrapper phrasings and minor punctuation/spacing differences from making the same prompt appear as multiple distinct stems in validation and round selection. 
- Make the validator and runtime use the same normalization so practice-wrapper variants are grouped consistently.
- Update documentation to reflect the stricter normalization and the true unique-stem counts so README claims match validator behavior.

### Description
- Replace the old one-line `stem()` helper in `scripts/validate-bank.mjs` with a `normalizeStem(...)` pipeline that trims, lowercases, strips the `'(Practice Variant N)'` suffix, removes known wrapper prefixes, and normalizes repeated punctuation/spacing before counting unique stems. 
- Use the normalized key for all duplicate/variant detection so the validator flags repeated normalized stems (not just explicit `Practice Variant` rows). 
- Mirror the same logic in `index.html` by adding `stripStemWrappers(...)` (clean display text) and `normalizeQuestionStem(...)` (lowercased key for grouping), and switch round-pool grouping to use `normalizeQuestionStem(...)` while keeping cleaned display via `questionStem(...)`. 
- Update `README.md` to reflect normalized counts and the tightened quality gate (now documenting 96 unique normalized stems per category / 672 total and that `npm test` enforces 100 normalized stems per category).

### Testing
- Ran the automated validation with `npm test`, which now fails as expected because the stricter normalization surfaces remaining duplicate normalized stems across categories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff3daa41c8323a70be632666b4375)