### PR TITLE
Restrict service worker offline fallback to navigation requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -14,18 +14,42 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const accepts = event.request.headers.get('accept') || '';
+  const isNavigationRequest =
+    event.request.mode === 'navigate' ||
+    event.request.destination === 'document' ||
+    accepts.includes('text/html');
+
   event.respondWith(
     caches.match(event.request).then((cached) => {
-      if (cached) return cached;
+      if (cached) {
+        return cached;
+      }
+
       return fetch(event.request)
         .then((response) => {
-          if (event.request.method === 'GET' && response.ok) {
+          if (response.ok) {
             const copy = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+            event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy)));
           }
           return response;
         })
-        .catch(() => caches.match('./index.html'));
+        .catch(async () => {
+          if (isNavigationRequest) {
+            return caches.match('./index.html');
+          }
+
+          const cachedResponse = await caches.match(event.request);
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+
+          throw new Error(`Network request failed for ${event.request.url}`);
+        });
     })
   );
 });


### PR DESCRIPTION
### Motivation
- Prevent the service worker from returning `index.html` for non-document requests, which can mask failed JSON/image/network calls.
- Avoid accidentally intercepting mutating requests by skipping non-`GET` methods at the top of the handler.
- Preserve the app shell offline behavior for top-level navigations while keeping regular asset fetch semantics intact.

### Description
- Early-return for non-`GET` requests in the `fetch` handler so `POST`/other methods are not intercepted.
- Detect navigation/document requests using `event.request.mode === 'navigate'`, `event.request.destination === 'document'`, and the `Accept` header containing `text/html`.
- Keep cache-first behavior: return cached response when present, otherwise fetch and update the cache from successful network responses using `event.waitUntil` to store clones.
- In the `.catch(...)` branch return `caches.match('./index.html')` only for navigation/document requests, otherwise try to return a cached match for the original request or let the fetch fail.

### Testing
- Ran a syntax/parse check with `node --check service-worker.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff3dc69608323a61ee0addc9a2560)