### PR TITLE
Improve CSV import parsing for quoted trivia rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Then open `http://localhost:4173`.
 - `index.html` still keeps an empty `#embeddedBank` slot only for one-file backup exports.
 - `npm test` validates `bank.json` directly.
 
+## Admin CSV import format
+
+- CSV imports must use this header row: `question,optionA,optionB,optionC,optionD,correct,explanation,difficulty,category`.
+- Wrap any text field that contains commas in double quotes so it stays in a single column.
+- Escape literal double quotes inside quoted text by doubling them as `""`.
+- Blank trailing columns are allowed and will still be imported as empty values.
+
 ## What changed for "next level"
 
 - **PWA support**: manifest + service worker + install button.

--- a/index.html
+++ b/index.html
@@ -959,6 +959,7 @@ details > summary { cursor: pointer; }
       <button class="btn btn-ghost" id="btnClearLocal">Clear Local</button>
       <button class="btn btn-ghost" id="btnOneFile">One-File Backup</button>
     </div>
+    <div class="muted" style="margin-top:12px">CSV import expects the header row <code>question,optionA,optionB,optionC,optionD,correct,explanation,difficulty,category</code>. Wrap any text field that contains commas in double quotes; escape literal quotes inside quoted text as <code>""</code>.</div>
     <div id="impMsg" class="muted" style="margin-top:12px"></div>
   </details>
 
@@ -1212,12 +1213,55 @@ $("#btnPlayAgain").onclick = ()=> startGame($("#btnPlayAgain")._cat);
 $("#btnResultHome").onclick= ()=> show("#screen-home");
 
 function csvToObjects(text){
-  const lines = text.replace(/\r/g,'').split('\n').filter(Boolean);
-  if (!lines.length) return [];
-  const head = lines.shift().split(',').map(s=>s.trim());
-  return lines.map(row=>{
-    const cols = row.split(',').map(s=>s.trim()); const obj = {};
-    head.forEach((h,i)=>obj[h]=cols[i] ?? '');
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++){
+    const ch = text[i];
+
+    if (ch === '"'){
+      if (inQuotes && text[i + 1] === '"'){
+        field += '"';
+        i++;
+      }else{
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (ch === ',' && !inQuotes){
+      row.push(field);
+      field = '';
+      continue;
+    }
+
+    if ((ch === '\n' || ch === '\r') && !inQuotes){
+      if (ch === '\r' && text[i + 1] === '\n') i++;
+      row.push(field);
+      const hasContent = row.some(col => String(col).trim() !== '');
+      if (hasContent) rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+
+    field += ch;
+  }
+
+  if (field.length || row.length){
+    row.push(field);
+    const hasContent = row.some(col => String(col).trim() !== '');
+    if (hasContent) rows.push(row);
+  }
+
+  if (!rows.length) return [];
+
+  const head = rows.shift().map(s => String(s).trim());
+  return rows.map(cols => {
+    const obj = {};
+    head.forEach((h, i) => { obj[h] = cols[i] ?? ''; });
     return {
       question: obj.question,
       options: [obj.optionA, obj.optionB, obj.optionC, obj.optionD],


### PR DESCRIPTION
### Motivation
- Admin CSV imports were using a naive `split(',')` approach which corrupts rows that contain commas or quotes, making realistic trivia content hard to import. 
- The import should support standard CSV features (quoted fields, escaped quotes, commas inside quotes, and blank trailing columns) while keeping existing validation/merge semantics. 

### Description
- Replaced `csvToObjects(text)` in `index.html` with a character-level CSV parser that supports quoted fields, doubled-quote escaping (`""`), embedded commas, and blank trailing columns. 
- Kept the existing header mapping to `question`, `optionA`–`optionD`, `correct`, `explanation`, `difficulty`, and `category` and preserved the downstream `validateQ(...)` and `dedupeMerge(...)` flow unchanged. 
- Added a short admin-facing note in the import panel and a matching section in `README.md` documenting the required header row and that comma-containing text fields must be wrapped in double quotes. 
- No changes to storage or dedupe logic; default fallback values (e.g. `difficulty: 'Masters'`) are preserved. 

### Testing
- Ran `npm test` (project validators) which completed successfully. 
- Ran a focused Node regression check that exercised quoted questions, embedded commas, escaped quotes, and blank trailing columns against `csvToObjects` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff3dd694483238bd310744883bad4)