### PR TITLE
Shared prompt wrapper normalization and banned-wrapper validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -965,6 +965,7 @@ details > summary { cursor: pointer; }
 
 <!-- Embedded BANK payload for one-file backups (replaced on backup) -->
 <script id="embeddedBank" type="application/json">{}</script>
+<script src="./shared/prompt-normalization.js"></script>
 
 <script>
 let BANK = {};
@@ -1049,28 +1050,12 @@ let persistedRoundQueues = loadRoundQueueState();
 
 function shuffle(a){ for (let i=a.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } return a; }
 function pickN(arr,n){ const copy=[...(arr||[])]; shuffle(copy); return copy.slice(0, Math.min(n, copy.length)); }
-const PRACTICE_VARIANT_SUFFIX = /\s*\(Practice Variant\s+\d+\)\s*$/i;
-const STEM_WRAPPER_PREFIXES = [
-  /^\s*Identify the correct answer for this prompt:\s*/i,
-  /^\s*Choose the option that best answers this question:\s*/i,
-];
-function stripStemWrappers(text){
-  let normalized = String(text||'').trim();
-  normalized = normalized.replace(PRACTICE_VARIANT_SUFFIX, '').trim();
-  STEM_WRAPPER_PREFIXES.forEach(prefix => {
-    normalized = normalized.replace(prefix, '').trim();
-  });
-  return normalized
-    .replace(/([!?.,:;])\1+/g, '$1')
-    .replace(/\s*([!?.,:;])\s*/g, '$1 ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
+const { normalizePromptStem, stripPromptWrappers } = globalThis.TriviaPromptNormalization;
 function normalizeQuestionStem(text){
-  return stripStemWrappers(text).toLowerCase();
+  return normalizePromptStem(text);
 }
 function questionStem(text){
-  return stripStemWrappers(text);
+  return stripPromptWrappers(text);
 }
 function cleanExplanation(text){ return String(text||'').replace(/\s*Variant\s+\d+\s+keeps\s+the\s+same\s+concept\s+with\s+reordered\s+options\.?\s*$/i,'').trim(); }
 function loadRoundQueueState(){
@@ -1299,7 +1284,7 @@ function validateQ(q){
       && Array.isArray(q.options) && q.options.length===4
       && [0,1,2,3].includes(q.correct);
 }
-function questionDedupKey(question){ return String(question||'').trim().toLowerCase(); }
+function questionDedupKey(question){ return normalizeQuestionStem(question); }
 function dedupeMerge(targetArr, incoming){
   const seen = new Set(targetArr.map(x=>questionDedupKey(x.question)));
   let add=0, skip=0, bad=0;

--- a/scripts/validate-bank.mjs
+++ b/scripts/validate-bank.mjs
@@ -1,29 +1,15 @@
 import { readFileSync } from 'node:fs';
+import promptNormalization from '../shared/prompt-normalization.js';
 
 const MIN_ROWS_PER_CATEGORY = 100;
 const MIN_UNIQUE_STEMS_PER_CATEGORY = 100;
 const MAX_ALLOWED_VARIANTS_PER_STEM = 1;
-const PRACTICE_VARIANT_SUFFIX = /\s*\(Practice Variant\s+\d+\)\s*$/i;
-const WRAPPER_PREFIXES = [
-  /^\s*Identify the correct answer for this prompt:\s*/i,
-  /^\s*Choose the option that best answers this question:\s*/i,
-];
+const {
+  findPromptWrapperMatch,
+  normalizePromptStem,
+} = promptNormalization;
 
 const bank = JSON.parse(readFileSync(new URL('../bank.json', import.meta.url), 'utf8'));
-
-function normalizeStem(text) {
-  let normalized = String(text || '').trim().toLowerCase();
-  normalized = normalized.replace(PRACTICE_VARIANT_SUFFIX, '').trim();
-  for (const prefix of WRAPPER_PREFIXES) {
-    normalized = normalized.replace(prefix, '').trim();
-  }
-  normalized = normalized
-    .replace(/([!?.,:;])\1+/g, '$1')
-    .replace(/\s*([!?.,:;])\s*/g, '$1 ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  return normalized;
-}
 
 let errorCount = 0;
 const summaries = [];
@@ -60,7 +46,15 @@ for (const [category, questions] of Object.entries(bank)) {
     }
     seenExact.add(normalizedQuestion);
 
-    const normalizedStem = normalizeStem(q.question);
+    const wrapperMatch = findPromptWrapperMatch(q.question);
+    if (wrapperMatch) {
+      console.error(
+        `Banned wrapper pattern "${wrapperMatch.name}" in ${category}[${idx}]: ${q.question}`,
+      );
+      errorCount += 1;
+    }
+
+    const normalizedStem = normalizePromptStem(q.question);
     stemCounts.set(normalizedStem, (stemCounts.get(normalizedStem) || 0) + 1);
   });
 

--- a/shared/prompt-normalization.js
+++ b/shared/prompt-normalization.js
@@ -1,0 +1,101 @@
+(function initPromptNormalization(globalScope, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  globalScope.TriviaPromptNormalization = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, () => {
+  const PRACTICE_VARIANT_SUFFIX = /\s*\(Practice Variant\s+\d+\)\s*$/i;
+  const WRAPPER_FAMILIES = [
+    {
+      name: 'identify-correct-answer',
+      pattern: /^\s*Identify the correct answer for this prompt:\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'choose-best-answer',
+      pattern: /^\s*Choose the option that best answers this question:\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'correct-response-to-prompt',
+      pattern: /^\s*What is the correct response to the prompt\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'best-solves-trivia-clue',
+      pattern: /^\s*Which option best solves this trivia clue:\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'select-best-answer',
+      pattern: /^\s*Select the best answer for the question\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'answer-belongs-with-prompt',
+      pattern: /^\s*What answer belongs with this prompt:\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'quiz-asks-which-answer',
+      pattern: /^\s*If a quiz asks\s*/i,
+      suffixPattern: /\s*,?\s*which answer is correct\?\s*$/i,
+      type: 'wrapped',
+    },
+    {
+      name: 'answer-this-prompt-correctly',
+      pattern: /^\s*Answer this prompt correctly:\s*/i,
+      type: 'prefix',
+    },
+    {
+      name: 'response-best-fits-question',
+      pattern: /^\s*Which response best fits the question\s*/i,
+      type: 'prefix',
+    },
+  ];
+
+  function normalizePromptPunctuation(text) {
+    return String(text || '')
+      .replace(/([!?.,:;])\1+/g, '$1')
+      .replace(/\s*([!?.,:;])\s*/g, '$1 ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function stripPromptWrappers(text) {
+    let normalized = String(text || '').trim();
+    normalized = normalized.replace(PRACTICE_VARIANT_SUFFIX, '').trim();
+    for (const wrapper of WRAPPER_FAMILIES) {
+      if (!wrapper.pattern.test(normalized)) continue;
+      normalized = normalized.replace(wrapper.pattern, '').trim();
+      if (wrapper.suffixPattern) {
+        normalized = normalized.replace(wrapper.suffixPattern, '').trim();
+      }
+      break;
+    }
+    return normalizePromptPunctuation(normalized);
+  }
+
+  function normalizePromptStem(text) {
+    return stripPromptWrappers(text).toLowerCase();
+  }
+
+  function findPromptWrapperMatch(text) {
+    const value = String(text || '').trim();
+    return WRAPPER_FAMILIES.find(wrapper => {
+      if (!wrapper.pattern.test(value)) return false;
+      if (wrapper.suffixPattern) return wrapper.suffixPattern.test(value);
+      return true;
+    }) || null;
+  }
+
+  return {
+    PRACTICE_VARIANT_SUFFIX,
+    WRAPPER_FAMILIES,
+    findPromptWrapperMatch,
+    normalizePromptPunctuation,
+    normalizePromptStem,
+    stripPromptWrappers,
+  };
+});


### PR DESCRIPTION
### Motivation
- Ensure all wrapper families present in `bank.json` are normalized consistently so grouping/deduping and validator use the same stem definition.
- Prevent shipping rows that still include wrapper phrasing by making the validator fail when a banned wrapper pattern is present.
- Centralize wrapper stripping, punctuation cleanup and wrapper detection so both Node and browser code share the same logic.

### Description
- Add `shared/prompt-normalization.js` which implements wrapper families, `stripPromptWrappers`, `normalizePromptStem`, `findPromptWrapperMatch`, and punctuation normalization for the requested wrappers including `What is the correct response to the prompt`, `Which option best solves this trivia clue:`, `Select the best answer for the question`, `What answer belongs with this prompt:`, and `If a quiz asks ... which answer is correct?`.
- Update `scripts/validate-bank.mjs` to import the shared helper, normalize stems with `normalizePromptStem` before counting unique stems, and emit a validation error when `findPromptWrapperMatch` identifies a banned wrapper on any row.
- Update `index.html` to load `shared/prompt-normalization.js` and to use `normalizePromptStem`, `stripPromptWrappers` for runtime grouping/draw logic and to use the same stem key in import deduplication (`questionDedupKey`), so browser runtime behavior matches validation.

### Testing
- Ran a quick Node sanity check that exercised `normalizePromptStem` and `findPromptWrapperMatch` against representative examples, and the helper returned the expected normalized stems and wrapper names (succeeded).
- Ran `npm test` (which runs `node scripts/validate-bank.mjs`) and the validator correctly fails against the current `bank.json` because the repository still contains rows matching the newly-banned wrapper families and duplicate normalized stems (fail, expected to surface these content issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c2c6eac48323ba4f2c3c5d590aa9)