### PR TITLE
Tighten admin import validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,7 +1324,7 @@ function csvToObjects(text){
   if (!rows.length) return [];
 
   const head = rows.shift().map(s => String(s).trim());
-  return rows.map(cols => {
+  return rows.map((cols, rowIndex) => {
     const obj = {};
     head.forEach((h, i) => { obj[h] = cols[i] ?? ''; });
     return {
@@ -1333,26 +1333,141 @@ function csvToObjects(text){
       correct: Number(obj.correct||0),
       explanation: obj.explanation||'',
       difficulty: obj.difficulty||'Masters',
-      category: obj.category||''
+      category: obj.category||'',
+      _importMeta: { source: 'csv', rowNumber: rowIndex + 2 },
     };
   });
 }
+function normalizeImportText(value){
+  return String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .toLowerCase();
+}
+function explanationSupportsAnswer(explanation, answer){
+  const normalizedAnswer = normalizeImportText(answer);
+  if (!normalizedAnswer) return false;
+  return normalizeImportText(explanation).includes(normalizedAnswer);
+}
 function validateQ(q){
+  const correctOption = Array.isArray(q?.options) ? q.options[q.correct] : '';
   return q && typeof q.question==='string' && q.question.trim()
       && Array.isArray(q.options) && q.options.length===4
-      && [0,1,2,3].includes(q.correct);
+      && [0,1,2,3].includes(q.correct)
+      && typeof q.explanation === 'string' && q.explanation.trim()
+      && typeof correctOption === 'string' && correctOption.trim();
 }
 function questionDedupKey(question){ return normalizeQuestionStem(question); }
-function dedupeMerge(targetArr, incoming){
-  const seen = new Set(targetArr.map(x=>questionDedupKey(x.question)));
-  let add=0, skip=0, bad=0;
-  for (const q of incoming){
-    if (!validateQ(q)) { bad++; continue; }
-    const key = questionDedupKey(q.question);
-    if (seen.has(key)) { skip++; continue; }
-    targetArr.push(q); seen.add(key); add++;
+function formatImportRowLabel(q, fallbackIndex){
+  const rowNumber = q?._importMeta?.rowNumber;
+  if (Number.isInteger(rowNumber)) return `row ${rowNumber}`;
+  return `item ${fallbackIndex + 1}`;
+}
+function validateImportedQuestion(q, context = {}){
+  const reasons = [];
+  const rowLabel = formatImportRowLabel(q, context.index ?? 0);
+  const options = Array.isArray(q?.options) ? q.options : [];
+  const normalizedStem = questionDedupKey(q?.question || '');
+  const strippedQuestion = stripQuestionWrappers(q?.question || '');
+
+  if (!validateQ(q)) {
+    if (!(q && typeof q.question === 'string' && q.question.trim())) reasons.push('question is empty');
+    if (!Array.isArray(q?.options) || q.options.length !== 4) reasons.push('must provide exactly four options');
+    if (![0,1,2,3].includes(q?.correct)) reasons.push('correct must be 0, 1, 2, or 3');
+    if (!(typeof q?.explanation === 'string' && q.explanation.trim())) reasons.push('explanation is required');
+    const correctOption = Array.isArray(q?.options) ? q.options[q.correct] : '';
+    if (!(typeof correctOption === 'string' && correctOption.trim())) reasons.push('correct option must be a non-empty string');
   }
-  return {add,skip,bad};
+
+  if (Array.isArray(options) && options.length === 4) {
+    const normalizedOptions = options.map(opt => typeof opt === 'string' ? opt.trim() : '');
+    normalizedOptions.forEach((opt, idx) => {
+      if (!opt) {
+        reasons.push(idx === q.correct ? `correct option ${idx + 1} is empty` : `distractor option ${idx + 1} is empty`);
+      }
+    });
+    const seenOptions = new Map();
+    normalizedOptions.forEach((opt, idx) => {
+      if (!opt) return;
+      const key = normalizeImportText(opt);
+      if (!key) return;
+      if (seenOptions.has(key)) {
+        reasons.push(`options ${seenOptions.get(key) + 1} and ${idx + 1} are duplicates`);
+      } else {
+        seenOptions.set(key, idx);
+      }
+    });
+  }
+
+  if (typeof q?.question === 'string' && q.question.trim()) {
+    if (!normalizedStem) reasons.push('question stem is empty after normalization');
+    if (normalizeImportText(q.question) !== normalizeImportText(strippedQuestion)) {
+      reasons.push('question uses a wrapped/variant prompt; import the canonical prompt stem instead');
+    }
+  }
+
+  const correctAnswer = Array.isArray(options) ? options[q.correct] : '';
+  if (typeof q?.explanation === 'string' && q.explanation.trim() && typeof correctAnswer === 'string' && correctAnswer.trim()) {
+    if (!explanationSupportsAnswer(q.explanation, correctAnswer)) {
+      reasons.push('explanation must reference or support the marked correct answer');
+    }
+  }
+
+  if (normalizedStem && context.seenBatchStems?.has(normalizedStem)) {
+    reasons.push('duplicate prompt stem within this import batch');
+  }
+  if (normalizedStem && context.existingStems?.has(normalizedStem)) {
+    reasons.push('duplicate prompt stem already exists in this category');
+  }
+
+  return { valid: reasons.length === 0, reasons, rowLabel, normalizedStem };
+}
+function dedupeMerge(targetArr, incoming){
+  const existingStems = new Set(targetArr.map(x=>questionDedupKey(x.question)));
+  const seenBatchStems = new Set();
+  const accepted = [];
+  const rejected = [];
+  for (const [index, rawQuestion] of incoming.entries()){
+    const q = rawQuestion && typeof rawQuestion === 'object'
+      ? { ...rawQuestion, _importMeta: rawQuestion._importMeta || { source: 'json', rowNumber: index + 1 } }
+      : rawQuestion;
+    const result = validateImportedQuestion(q, { index, existingStems, seenBatchStems });
+    if (!result.valid) {
+      rejected.push({ rowLabel: result.rowLabel, question: q?.question || '', reasons: result.reasons });
+      continue;
+    }
+    accepted.push({
+      question: q.question,
+      options: q.options,
+      correct: q.correct,
+      explanation: q.explanation,
+      difficulty: q.difficulty || 'Masters',
+      category: q.category || '',
+    });
+    seenBatchStems.add(result.normalizedStem);
+  }
+
+  if (rejected.length) {
+    return { add:0, skip:0, bad:rejected.length, rejected, committed:false };
+  }
+
+  for (const q of accepted){
+    targetArr.push(q);
+    existingStems.add(questionDedupKey(q.question));
+  }
+  return { add:accepted.length, skip:0, bad:0, rejected:[], committed:true };
+}
+function formatRejectedRows(rejected, limit = 6){
+  if (!rejected.length) return '';
+  const lines = rejected.slice(0, limit).map(entry => {
+    const question = String(entry.question || '').trim();
+    const label = `${entry.rowLabel}: ${entry.reasons.join('; ')}`;
+    return question ? `${label} — ${question}` : label;
+  });
+  const more = rejected.length > limit ? ` (+${rejected.length - limit} more)` : '';
+  return ` Rejected rows: ${lines.join(' | ')}${more}`;
 }
 function saveLocal(){ try{ localStorage.setItem(BANK_LOCAL_STORAGE_KEY, JSON.stringify(BANK)); persistBundledBankVersion(); }catch{} }
 function download(name, text, type='application/json'){
@@ -1369,9 +1484,16 @@ $("#btnImport")?.addEventListener('click', async ()=>{
   try{ arr = f.name.toLowerCase().endsWith('.csv') ? csvToObjects(txt) : JSON.parse(txt); }
   catch(e){ msg.textContent='Parse error: '+e.message; return; }
   if (!Array.isArray(arr)){ msg.textContent='File must be an array of questions.'; return; }
-  BANK[cat] = BANK[cat]||[]; const res = dedupeMerge(BANK[cat], arr);
+  const current = BANK[cat] || [];
+  const next = current.slice();
+  const res = dedupeMerge(next, arr);
+  if (!res.committed) {
+    msg.textContent = `Import blocked for "${cat}": ${res.bad} invalid row(s). Nothing was saved.` + formatRejectedRows(res.rejected);
+    return;
+  }
+  BANK[cat] = next;
   saveLocal(); rebuildCategoryPools(); updateHomeCounts();
-  msg.textContent = `Imported into "${cat}": +${res.add} added, ${res.skip} duplicates, ${res.bad} invalid. Total ${BANK[cat].length}.`;
+  msg.textContent = `Imported into "${cat}": +${res.add} added. Total ${BANK[cat].length}. Batch passed strict validation.`;
 });
 
 $("#btnImportAll")?.addEventListener('click', async ()=>{
@@ -1379,20 +1501,31 @@ $("#btnImportAll")?.addEventListener('click', async ()=>{
   try{
     const obj = JSON.parse(await f.text());
     if (!obj || typeof obj!=='object') throw new Error('Not an object');
-    const totals = { add:0, skip:0, bad:0, imported:0, ignored:[] };
+    const nextBank = { ...BANK };
+    const totals = { add:0, skip:0, bad:0, imported:0, ignored:[], rejected:[] };
     for (const [k, arr] of Object.entries(obj)){
       if (!Array.isArray(arr)) continue;
       if (!supportedCategories.has(k)) { totals.ignored.push(k); continue; }
-      BANK[k] = BANK[k] || [];
-      const res = dedupeMerge(BANK[k], arr);
+      const nextCategory = (nextBank[k] || []).slice();
+      const res = dedupeMerge(nextCategory, arr);
       totals.add += res.add;
       totals.skip += res.skip;
       totals.bad += res.bad;
       totals.imported++;
+      if (!res.committed) {
+        totals.rejected.push(`${k}: ${res.bad} invalid row(s).${formatRejectedRows(res.rejected)}`);
+        continue;
+      }
+      nextBank[k] = nextCategory;
     }
+    if (totals.rejected.length) {
+      msg.textContent = `ALL import blocked: ${totals.bad} invalid row(s) across ${totals.rejected.length} categorie(s). Nothing was saved. ${totals.rejected.join(' ')}`;
+      return;
+    }
+    Object.assign(BANK, nextBank);
     saveLocal(); rebuildCategoryPools(); updateHomeCounts();
     const detail = totals.imported
-      ? `Imported ${totals.imported} categories: +${totals.add} added, ${totals.skip} duplicates, ${totals.bad} invalid.`
+      ? `Imported ${totals.imported} categories: +${totals.add} added. Batch passed strict validation.`
       : 'No supported categories found in ALL import.';
     const ignored = totals.ignored.length
       ? ` Ignored unknown categories: ${totals.ignored.join(', ')}.`


### PR DESCRIPTION
### Motivation
- Make the admin import pipeline stricter so externally imported questions match the same quality and prompt-stem rules as the bundled bank and avoid silently persisting bad rows.
- Require a non-empty explanation and a non-empty correct option for each imported row so imports are useful for play and for later validation/audit.
- Detect and reject common import problems (duplicate/empty options, wrapped/variant prompts, explanations that don't reference the marked answer) and surface those failures immediately to the admin UI.
- Ensure imports are committed only when the entire batch passes the stricter validation policy to avoid partial/poisoned local persistence.

### Description
- Expanded `validateQ` to require a non-empty `explanation` and that the marked `correct` option is a non-empty string in addition to the existing schema checks (`question`, four `options`, correct index). 
- Reused the prompt normalization helpers (`normalizeQuestionStem` / `stripQuestionWrappers`) to check imported prompt stems against the same normalization rules as bundled content and detect wrapped/variant prompts.
- Added CSV row metadata in `csvToObjects` (`_importMeta.rowNumber`) so error messages can reference source rows.
- Added `normalizeImportText` and `explanationSupportsAnswer` helpers plus `validateImportedQuestion` to run stronger row-level checks for empty distractors, duplicate options (normalized), wrapped prompts, explanation→answer support, and duplicate stems within the batch or against the existing category.
- Reworked `dedupeMerge` to validate the entire incoming batch producing `accepted` and `rejected` lists, return a `committed` flag, and avoid mutating `BANK` unless the whole batch is valid; accepted rows are normalized/reshaped before append.
- Added `formatRejectedRows` to produce compact human-readable reasons for rejected rows and surfaced those reasons in the admin messages for both single-category import and ALL-import flows.
- Changed import handlers for `#btnImport` and `#btnImportAll` to use a cloned bank/category for validation and perform an all-or-nothing commit: if any row is rejected the import is blocked and rejects are shown; only fully valid batches are persisted to `localStorage`.

### Testing
- Ran `npm test` (which executes `node scripts/validate-bank.mjs`) and it reported the canonical bank validation succeeded (`Bank OK`), so validation helpers remain compatible with the canonical bank.
- Performed a runtime smoke check by executing each embedded `<script>` body with `new Function(...)` to verify there are no syntax/runtime errors in the modified `index.html`, and all scripts loaded successfully.
- Verified the admin import flows locally by exercising the import handlers (CSV/JSON parsing path), and confirmed that invalid rows are reported in the `#impMsg` text and no partial writes are persisted when rejects exist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c153163944832389560f7bc03febea)