### PR TITLE
Require fact review entries for shipped bank rows

### DIFF
--- a/scripts/validate-bank.mjs
+++ b/scripts/validate-bank.mjs
@@ -109,7 +109,9 @@ for (const [category, questions] of Object.entries(bank)) {
 
     const reviewKey = buildQuestionKey(category, q.question, correctOption);
     const reviewEntry = reviewIndex.get(reviewKey);
-    if (reviewEntry && reviewEntry.status !== 'verified') {
+    if (!reviewEntry) {
+      fail(`Missing fact review entry for ${category}[${idx}]: ${q.question}`);
+    } else if (reviewEntry.status !== 'verified') {
       fail(`Fact review entry is not verified for ${category}[${idx}]: ${q.question}`);
     }
   });


### PR DESCRIPTION
### Motivation
- Enforce that every shipped question row has a corresponding manual fact-review entry so validation reflects audit coverage requirements.
- Preserve the existing check that any present review entry must have `status === "verified"`.

### Description
- Updated the per-question validation in `scripts/validate-bank.mjs` to fail when a matching review entry is missing, and kept the existing failure when a review exists but is not `verified`.
- The new failure message includes the category, row index, and prompt text for easy locating (format: `Missing fact review entry for <category>[<idx>]: <prompt>`).
- The change continues to use the existing helper flow (`buildQuestionKey`, `buildReviewIndex`, `loadReviewMetadata`) so behavior aligns with `scripts/audit-bank.mjs` coverage logic.

### Testing
- Ran `node scripts/validate-bank.mjs`, which now reports missing fact review entries for uncovered rows and then surfaced a pre-existing `ReferenceError: BARE_TRANSLATION_PROMPT_RE` in the validator.
- Ran `node scripts/audit-bank.mjs`, which completed successfully and wrote the audit JSON report while reporting fact review coverage `2/840` rows.
- Confirmed behavior aligns with the audit language where `FACT_REVIEWED_PASS` is only possible when `reviewCoverage.fullyReviewed` is true.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1658b975c8323853457ae74f30bdd)